### PR TITLE
CommandHandler: Always log the interaction

### DIFF
--- a/src/commandHandler.ts
+++ b/src/commandHandler.ts
@@ -25,7 +25,7 @@ export default class CommandHandler {
   private readonly commands: Map<string[], Command>;
   private readonly help: string;
 
-  constructor(private readonly production: boolean) {
+  constructor() {
     const availableCommands = new Array<string>();
 
     this.commands = new Map(
@@ -70,15 +70,12 @@ export default class CommandHandler {
 
   /** Executes user commands contained in a message if appropriate. */
   async handleCommandInteraction(interaction: Interaction): Promise<void> {
-    if (!this.production) {
-      const msg = `Buggie bot received ${JSON.stringify(
-        interaction,
-        (_, v) => (typeof v === "bigint" ? `${v.toString()}n` : v),
-        4
-      )} from '${interaction.user.tag}`;
-      // await interaction.channel?.send(msg);
-      console.log(msg);
-    }
+    const msg = `Buggie bot received ${JSON.stringify(
+      interaction,
+      (_, v) => (typeof v === "bigint" ? `${v.toString()}n` : v),
+      4
+    )} from '${interaction.user.tag}`;
+    console.log(msg);
 
     if (!interaction.isCommand()) throw new Error("Invalid command interaction");
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -15,7 +15,6 @@ import Discord, {
   Partials,
 } from "discord.js";
 import CommandHandler from "@/commandHandler";
-import config from "@/config/botConfig";
 import { env } from "@/config/env";
 
 process.on("unhandledRejection", reason => {
@@ -31,7 +30,7 @@ const client = new Discord.Client({
   partials: [Partials.Message, Partials.Channel, Partials.Reaction],
 });
 
-const commandHandler = new CommandHandler(config.production);
+const commandHandler = new CommandHandler();
 
 client.once(Events.ClientReady, () => {
   if (client.user != null) {


### PR DESCRIPTION
When issues arise in production, we now might have an idea of what caused it.

Also remove the production bool from CommandHandler; it can just retrieve that from `config`.