### PR TITLE
fix: Suppress embeds correctly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -67,11 +67,12 @@ client.on(Events.Error, e => {
 
 // Message updates contain full data. Typings are corrected in a newer discord.js version.
 client.on(Events.MessageUpdate, async (_, newMessage) => {
-  await suppressGitHubUnfurl(newMessage as Message);
+  if (!newMessage.inGuild()) return;
+  await suppressGitHubUnfurl(newMessage as Message<true>);
 });
 
 client.on(Events.MessageCreate, async (message: Message<boolean>) => {
-  if (message.author.bot) return;
+  if (message.author.bot || !message.inGuild()) return;
   await suppressGitHubUnfurl(message);
 });
 

--- a/src/util/suppressGitHubUnfurl.ts
+++ b/src/util/suppressGitHubUnfurl.ts
@@ -1,7 +1,13 @@
-import { Message, MessageFlags } from "discord.js";
+import { Message, MessageFlags, PermissionFlagsBits } from "discord.js";
 
-export async function suppressGitHubUnfurl(message: Message) {
+export async function suppressGitHubUnfurl(message: Message<true>) {
   if (message.flags.has(MessageFlags.SuppressEmbeds)) return;
+  const me = await message.guild.members.fetch(message.client.user.id);
+
+  if (!message.channel.permissionsFor(me).has(PermissionFlagsBits.ManageMessages)) {
+    console.log("Missing permissions to suppress embeds.");
+    return;
+  }
 
   for (const embed of message.embeds) {
     if (!embed.url) continue;

--- a/src/util/suppressGitHubUnfurl.ts
+++ b/src/util/suppressGitHubUnfurl.ts
@@ -1,0 +1,18 @@
+import { Message, MessageFlags } from "discord.js";
+
+export async function suppressGitHubUnfurl(message: Message) {
+  if (message.flags.has(MessageFlags.SuppressEmbeds)) return;
+
+  for (const embed of message.embeds) {
+    if (!embed.url) continue;
+    const url = new URL(embed.url);
+    if (url.host !== "github.com") continue;
+    const segments = url.pathname.split("/");
+    const githubUrlType: string | undefined = segments[3];
+
+    if (githubUrlType === "tree" || githubUrlType === "blob") {
+      await message.edit({ flags: message.flags.bitfield | MessageFlags.SuppressEmbeds });
+      return;
+    }
+  }
+}


### PR DESCRIPTION
The existing implementation is not correct.

First of all, there is no message content intent. That means you receive no embeds, and thus, this entire code path is doing nothing at all.

Unfurls in Discord are sent in the embeds array. The message content intent is required for this to populate. Furthermore, unfurls do not always happen on message create. Unfurls may take a few seconds, maybe 5 at maximum, to unfurl. When it doesn't arrive on message create, it arrives on message update.

It seems clear this line was added to attempt to fix the issue:

https://github.com/LadybirdBrowser/discord-bot/blob/bd1aa26c4c362c38de75b73c2d779886b55b3517/src/index.ts#L67

However, it's not actually fixing the issue. It just seems like it does because you're waiting for an API call to resolve. It's a coincidence.

The code has been refactored into a function that utilises both message create and message update. Also, since updating a message triggers message update, an early exit check has been added.

> [!IMPORTANT]  
> I can see LadybirdBot does not have the message content intent enabled in the developer portal. That must be switched on for this to merge.